### PR TITLE
HTTPS Support

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,12 @@ MYSQL_ROOT_PW=chris@L1
 MYSQL_LOCAL_PORT=3307
 MYSQL_DOCKER_PORT=3306
 
-NISSHI_LOCAL_PORT=80
-NISSHI_DOCKER_PORT=80
+NISSHI_LOCAL_HTTP_PORT=80
+NISSHI_DOCKER_HTTP_PORT=5000
+NISSHI_LOCAL_HTTPS_PORT=443
+NISSHI_DOCKER_HTTPS_PORT=5001
 ASPNETCORE_Nisshi_DatabaseProvider=mysql
 ASPNETCORE_Nisshi_ConnectionString=server=db;uid=nisshiuser;pwd=saishoNoYuuza1?;database=nisshi
+ASPNETCORE_Nisshi_CertificatePassword=h1M1t5u#!
+ASPNETCORE_Nisshi_CertificatePath=/https/Nisshi.pfx
+ASPNETCORE_Nisshi_Environment=Production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,12 @@ services:
     environment:
      - ASPNETCORE_Nisshi_DatabaseProvider=${ASPNETCORE_Nisshi_DatabaseProvider}
      - ASPNETCORE_Nisshi_ConnectionString=${ASPNETCORE_Nisshi_ConnectionString}
+     - ASPNETCORE_URLS=https://+;http://+
+     - ASPNETCORE_Kestrel__Certificates__Default__Password=${ASPNETCORE_Nisshi_CertificatePassword}
+     - ASPNETCORE_Kestrel__Certificates__Default__Path=${ASPNETCORE_Nisshi_CertificatePath}
+     - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_Nisshi_Environment}
     ports:
-     - ${NISSHI_LOCAL_PORT}:${NISSHI_DOCKER_PORT}
+     - ${NISSHI_LOCAL_HTTP_PORT}:${NISSHI_DOCKER_HTTP_PORT}
+     - ${NISSHI_LOCAL_HTTPS_PORT}:${NISSHI_DOCKER_HTTPS_PORT}
+    volumes:
+     - ~/.aspnet/https:/https:ro


### PR DESCRIPTION
- Added environment variables to use HTTPS with a temp dev certificate
- Need to run the following line before first running the project in linux:

dotnet dev-certs https -ep ${HOME}/.aspnet/https/Nisshi.pfx -p h1M1t5u#!